### PR TITLE
azure pipeline needs to build frontend assets

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,6 +77,14 @@ stages:
                 nuget
               path: $(NUGET_PACKAGES)
 
+          - script: npm ci
+            displayName: Install NPM packages
+            workingDirectory: src/Flip/Client
+
+          - script: npm run build
+            displayName: Build client assets
+            workingDirectory: src/Flip/Client
+
           - script: dotnet restore $(solution) --locked-mode
             displayName: Restore NuGet packages
 


### PR DESCRIPTION
Hey Nathan!

v17.0.1 on nuget is still missing the frontend assets. I downloaded the .nupkg from nuget and this is what NuGet Package Explorer shows - i.e. no `staticwebassets` folder.

<img width="576" height="273" alt="image" src="https://github.com/user-attachments/assets/13325e26-c510-4c20-ac04-3d560fe3ae86" />

Claude and I had a look and it did make a sensible suggestion: the azure pipelines is missing the build step for the frontend assets. So that is what this PR is adding.

I admit that I haven't been able to test this myself because, pipelines...! , but I thought I'd at least submit it for you in case this was the correct reason!